### PR TITLE
Massive product catalog expansion with premium devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
                 <div class="product-card" data-category="smartphones">
                     <div class="product-image">
                         <div class="product-badge">New</div>
-                        <img src="https://images.unsplash.com/photo-1592750475338-74b7b21085ab?w=500&h=500&fit=crop" alt="iPhone 15 Pro Max" class="product-img">
+                        <img src="https://images.unsplash.com/photo-1592750475338-74b7b21085ab?w=1200&h=1200&fit=crop&crop=center&q=90" alt="iPhone 15 Pro Max" class="product-img">
                         <div class="product-overlay">
                             <button class="quick-view-btn">Quick View</button>
                         </div>
@@ -108,7 +108,7 @@
                 <div class="product-card" data-category="smartphones">
                     <div class="product-image">
                         <div class="product-badge">Popular</div>
-                        <img src="https://images.unsplash.com/photo-1511707171634-5f897ff02aa9?w=500&h=500&fit=crop" alt="Samsung Galaxy S24 Ultra" class="product-img">
+                        <img src="https://images.unsplash.com/photo-1511707171634-5f897ff02aa9?w=1200&h=1200&fit=crop&crop=center&q=90" alt="Samsung Galaxy S24 Ultra" class="product-img">
                         <div class="product-overlay">
                             <button class="quick-view-btn">Quick View</button>
                         </div>
@@ -131,7 +131,7 @@
 
                 <div class="product-card" data-category="smartphones">
                     <div class="product-image">
-                        <img src="https://images.unsplash.com/photo-1574944985070-8f3ebc6b79d2?w=500&h=500&fit=crop" alt="Google Pixel 8 Pro" class="product-img">
+                        <img src="https://images.unsplash.com/photo-1574944985070-8f3ebc6b79d2?w=1200&h=1200&fit=crop&crop=center&q=90" alt="Google Pixel 8 Pro" class="product-img">
                         <div class="product-overlay">
                             <button class="quick-view-btn">Quick View</button>
                         </div>
@@ -152,11 +152,398 @@
                     </div>
                 </div>
 
+                <!-- Additional iPhones -->
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Classic</div>
+                        <img src="https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=800&h=800&fit=crop&crop=center" alt="iPhone X" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">iPhone X</h3>
+                        <p class="product-description">Revolutionary Face ID and edge-to-edge display - Good condition</p>
+                        <div class="product-specs">
+                            <span>64GB</span>
+                            <span>Face ID</span>
+                            <span>OLED</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R3,999</span>
+                            <span class="original-price">R7,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="iPhone X" data-price="3999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Value</div>
+                        <img src="https://images.unsplash.com/photo-1556656793-08538906a9f8?w=800&h=800&fit=crop&crop=center" alt="iPhone XR" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">iPhone XR</h3>
+                        <p class="product-description">Colorful design with great battery life - Very good condition</p>
+                        <div class="product-specs">
+                            <span>128GB</span>
+                            <span>Liquid Retina</span>
+                            <span>Face ID</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R4,499</span>
+                            <span class="original-price">R8,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="iPhone XR" data-price="4499">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Popular</div>
+                        <img src="https://images.unsplash.com/photo-1574944985070-8f3ebc6b79d2?w=800&h=800&fit=crop&crop=center" alt="iPhone 11" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">iPhone 11</h3>
+                        <p class="product-description">Dual camera system with Night mode - Excellent condition</p>
+                        <div class="product-specs">
+                            <span>128GB</span>
+                            <span>Dual Camera</span>
+                            <span>A13 Bionic</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R5,999</span>
+                            <span class="original-price">R11,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="iPhone 11" data-price="5999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Pro</div>
+                        <img src="https://images.unsplash.com/photo-1603891128711-11b4b03bb138?w=800&h=800&fit=crop&crop=center" alt="iPhone 11 Pro" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">iPhone 11 Pro</h3>
+                        <p class="product-description">Triple camera system with Pro features - Very good condition</p>
+                        <div class="product-specs">
+                            <span>256GB</span>
+                            <span>Triple Camera</span>
+                            <span>Super Retina XDR</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R7,499</span>
+                            <span class="original-price">R14,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="iPhone 11 Pro" data-price="7499">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Max</div>
+                        <img src="https://images.unsplash.com/photo-1605236453806-6ff36851218e?w=800&h=800&fit=crop&crop=center" alt="iPhone 11 Pro Max" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">iPhone 11 Pro Max</h3>
+                        <p class="product-description">Largest Pro display with incredible battery - Excellent condition</p>
+                        <div class="product-specs">
+                            <span>256GB</span>
+                            <span>6.5" Display</span>
+                            <span>Triple Camera</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R8,499</span>
+                            <span class="original-price">R16,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="iPhone 11 Pro Max" data-price="8499">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Advanced</div>
+                        <img src="https://images.unsplash.com/photo-1632633173522-3c89e85a8f3e?w=800&h=800&fit=crop&crop=center" alt="iPhone 13" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">iPhone 13</h3>
+                        <p class="product-description">Cinematic mode and improved cameras - Like new condition</p>
+                        <div class="product-specs">
+                            <span>128GB</span>
+                            <span>Cinematic Mode</span>
+                            <span>A15 Bionic</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R9,999</span>
+                            <span class="original-price">R19,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="iPhone 13" data-price="9999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Pro</div>
+                        <img src="https://images.unsplash.com/photo-1643208589889-0735ad7218f0?w=800&h=800&fit=crop&crop=center" alt="iPhone 13 Pro" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">iPhone 13 Pro</h3>
+                        <p class="product-description">ProMotion display with macro photography - Excellent condition</p>
+                        <div class="product-specs">
+                            <span>256GB</span>
+                            <span>120Hz ProMotion</span>
+                            <span>Macro Camera</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R12,999</span>
+                            <span class="original-price">R25,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="iPhone 13 Pro" data-price="12999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Max</div>
+                        <img src="https://images.unsplash.com/photo-1643208477230-5a9e8c7e3b1b?w=800&h=800&fit=crop&crop=center" alt="iPhone 13 Pro Max" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">iPhone 13 Pro Max</h3>
+                        <p class="product-description">Ultimate iPhone with largest Pro display - Like new condition</p>
+                        <div class="product-specs">
+                            <span>512GB</span>
+                            <span>6.7" ProMotion</span>
+                            <span>Pro Camera System</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R14,999</span>
+                            <span class="original-price">R29,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="iPhone 13 Pro Max" data-price="14999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <!-- Samsung Galaxy Phones -->
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Flagship</div>
+                        <img src="https://images.unsplash.com/photo-1610945265064-0e34e5519bbf?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy S23" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy S23</h3>
+                        <p class="product-description">Snapdragon 8 Gen 2 with improved cameras - Very good condition</p>
+                        <div class="product-specs">
+                            <span>128GB</span>
+                            <span>50MP Camera</span>
+                            <span>Snapdragon 8 Gen 2</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R11,999</span>
+                            <span class="original-price">R23,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy S23" data-price="11999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Plus</div>
+                        <img src="https://images.unsplash.com/photo-1610945265064-0e34e5519bbf?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy S23+" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy S23+</h3>
+                        <p class="product-description">Larger display with premium features - Excellent condition</p>
+                        <div class="product-specs">
+                            <span>256GB</span>
+                            <span>6.6" Display</span>
+                            <span>4700mAh Battery</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R13,999</span>
+                            <span class="original-price">R27,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy S23+" data-price="13999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Latest</div>
+                        <img src="https://images.unsplash.com/photo-1610945265064-0e34e5519bbf?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy S24+" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy S24+</h3>
+                        <p class="product-description">Latest Galaxy with AI features - Like new condition</p>
+                        <div class="product-specs">
+                            <span>256GB</span>
+                            <span>AI Features</span>
+                            <span>Snapdragon 8 Gen 3</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R15,999</span>
+                            <span class="original-price">R31,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy S24+" data-price="15999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <!-- Samsung Mid-range Phones -->
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Mid-range</div>
+                        <img src="https://images.unsplash.com/photo-1598300042247-d088f8ab3a91?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy A54" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy A54</h3>
+                        <p class="product-description">Premium mid-range with great cameras - Very good condition</p>
+                        <div class="product-specs">
+                            <span>128GB</span>
+                            <span>50MP OIS</span>
+                            <span>Exynos 1380</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R4,999</span>
+                            <span class="original-price">R9,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy A54" data-price="4999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Budget</div>
+                        <img src="https://images.unsplash.com/photo-1598300042247-d088f8ab3a91?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy A34" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy A34</h3>
+                        <p class="product-description">Affordable with solid performance - Good condition</p>
+                        <div class="product-specs">
+                            <span>128GB</span>
+                            <span>48MP Camera</span>
+                            <span>Dimensity 1080</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R3,499</span>
+                            <span class="original-price">R6,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy A34" data-price="3499">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Value</div>
+                        <img src="https://images.unsplash.com/photo-1598300042247-d088f8ab3a91?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy A14" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy A14</h3>
+                        <p class="product-description">Entry-level with 5G connectivity - Good condition</p>
+                        <div class="product-specs">
+                            <span>64GB</span>
+                            <span>50MP Main</span>
+                            <span>5G Ready</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R2,499</span>
+                            <span class="original-price">R4,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy A14" data-price="2499">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Gaming</div>
+                        <img src="https://images.unsplash.com/photo-1598300042247-d088f8ab3a91?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy M54" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy M54</h3>
+                        <p class="product-description">Gaming focused with large battery - Very good condition</p>
+                        <div class="product-specs">
+                            <span>128GB</span>
+                            <span>108MP Camera</span>
+                            <span>6000mAh Battery</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R4,499</span>
+                            <span class="original-price">R8,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy M54" data-price="4499">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartphones">
+                    <div class="product-image">
+                        <div class="product-badge">Compact</div>
+                        <img src="https://images.unsplash.com/photo-1598300042247-d088f8ab3a91?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy A24" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy A24</h3>
+                        <p class="product-description">Compact design with reliable performance - Good condition</p>
+                        <div class="product-specs">
+                            <span>128GB</span>
+                            <span>50MP Triple</span>
+                            <span>Helio G99</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R2,999</span>
+                            <span class="original-price">R5,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy A24" data-price="2999">Add to Cart</button>
+                    </div>
+                </div>
+
                 <!-- Laptops -->
                 <div class="product-card" data-category="laptops">
                     <div class="product-image">
                         <div class="product-badge">Premium</div>
-                        <img src="https://images.unsplash.com/photo-1541807084-5c52b6b3adef?w=500&h=500&fit=crop" alt="MacBook Pro 16" class="product-img">
+                        <img src="https://images.unsplash.com/photo-1541807084-5c52b6b3adef?w=1200&h=1200&fit=crop&crop=center&q=90" alt="MacBook Pro 16" class="product-img">
                         <div class="product-overlay">
                             <button class="quick-view-btn">Quick View</button>
                         </div>
@@ -180,7 +567,7 @@
                 <div class="product-card" data-category="laptops">
                     <div class="product-image">
                         <div class="product-badge">Gaming</div>
-                        <img src="https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=500&h=500&fit=crop" alt="ASUS ROG Strix G16" class="product-img">
+                        <img src="https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=1200&h=1200&fit=crop&crop=center&q=90" alt="ASUS ROG Strix G16" class="product-img">
                         <div class="product-overlay">
                             <button class="quick-view-btn">Quick View</button>
                         </div>
@@ -203,7 +590,7 @@
 
                 <div class="product-card" data-category="laptops">
                     <div class="product-image">
-                        <img src="https://images.unsplash.com/photo-1496181133206-80ce9b88a853?w=500&h=500&fit=crop" alt="Dell XPS 13 Plus" class="product-img">
+                        <img src="https://images.unsplash.com/photo-1496181133206-80ce9b88a853?w=1200&h=1200&fit=crop&crop=center&q=90" alt="Dell XPS 13 Plus" class="product-img">
                         <div class="product-overlay">
                             <button class="quick-view-btn">Quick View</button>
                         </div>
@@ -224,11 +611,230 @@
                     </div>
                 </div>
 
+                <!-- HP Laptops -->
+                <div class="product-card" data-category="laptops">
+                    <div class="product-image">
+                        <div class="product-badge">Entry</div>
+                        <img src="https://images.unsplash.com/photo-1588872657578-7efd1f1555ed?w=800&h=800&fit=crop&crop=center" alt="HP Pavilion i3" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">HP Pavilion 15 (i3)</h3>
+                        <p class="product-description">Perfect for everyday computing and students - Good condition</p>
+                        <div class="product-specs">
+                            <span>256GB SSD</span>
+                            <span>8GB RAM</span>
+                            <span>Intel i3-1215U</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R6,999</span>
+                            <span class="original-price">R13,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="HP Pavilion 15 (i3)" data-price="6999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="laptops">
+                    <div class="product-image">
+                        <div class="product-badge">Performance</div>
+                        <img src="https://images.unsplash.com/photo-1588872657578-7efd1f1555ed?w=800&h=800&fit=crop&crop=center" alt="HP Envy i5" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">HP Envy x360 (i5)</h3>
+                        <p class="product-description">Convertible design with solid performance - Very good condition</p>
+                        <div class="product-specs">
+                            <span>512GB SSD</span>
+                            <span>16GB RAM</span>
+                            <span>Intel i5-1235U</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R11,999</span>
+                            <span class="original-price">R23,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="HP Envy x360 (i5)" data-price="11999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="laptops">
+                    <div class="product-image">
+                        <div class="product-badge">Power</div>
+                        <img src="https://images.unsplash.com/photo-1588872657578-7efd1f1555ed?w=800&h=800&fit=crop&crop=center" alt="HP Spectre i7" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">HP Spectre x360 (i7)</h3>
+                        <p class="product-description">Premium ultrabook with stunning design - Excellent condition</p>
+                        <div class="product-specs">
+                            <span>1TB SSD</span>
+                            <span>16GB RAM</span>
+                            <span>Intel i7-1255U</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R16,999</span>
+                            <span class="original-price">R33,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="HP Spectre x360 (i7)" data-price="16999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <!-- Additional Dell Laptops -->
+                <div class="product-card" data-category="laptops">
+                    <div class="product-image">
+                        <div class="product-badge">Basic</div>
+                        <img src="https://images.unsplash.com/photo-1541807084-5c52b6b3adef?w=800&h=800&fit=crop&crop=center" alt="Dell Inspiron i3" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Dell Inspiron 15 (i3)</h3>
+                        <p class="product-description">Reliable everyday laptop for work and study - Good condition</p>
+                        <div class="product-specs">
+                            <span>256GB SSD</span>
+                            <span>8GB RAM</span>
+                            <span>Intel i3-1215U</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R6,499</span>
+                            <span class="original-price">R12,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Dell Inspiron 15 (i3)" data-price="6499">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="laptops">
+                    <div class="product-image">
+                        <div class="product-badge">Balanced</div>
+                        <img src="https://images.unsplash.com/photo-1541807084-5c52b6b3adef?w=800&h=800&fit=crop&crop=center" alt="Dell Latitude i5" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Dell Latitude 5520 (i5)</h3>
+                        <p class="product-description">Business-grade laptop with excellent build quality - Very good condition</p>
+                        <div class="product-specs">
+                            <span>512GB SSD</span>
+                            <span>16GB RAM</span>
+                            <span>Intel i5-1145G7</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R12,999</span>
+                            <span class="original-price">R25,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Dell Latitude 5520 (i5)" data-price="12999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="laptops">
+                    <div class="product-image">
+                        <div class="product-badge">Professional</div>
+                        <img src="https://images.unsplash.com/photo-1541807084-5c52b6b3adef?w=800&h=800&fit=crop&crop=center" alt="Dell Precision i7" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Dell Precision 5570 (i7)</h3>
+                        <p class="product-description">Workstation-class performance for professionals - Excellent condition</p>
+                        <div class="product-specs">
+                            <span>1TB SSD</span>
+                            <span>32GB RAM</span>
+                            <span>Intel i7-12700H</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R22,999</span>
+                            <span class="original-price">R45,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Dell Precision 5570 (i7)" data-price="22999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <!-- Additional ASUS Laptops -->
+                <div class="product-card" data-category="laptops">
+                    <div class="product-image">
+                        <div class="product-badge">Student</div>
+                        <img src="https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=800&h=800&fit=crop&crop=center" alt="ASUS VivoBook i3" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">ASUS VivoBook 15 (i3)</h3>
+                        <p class="product-description">Colorful and affordable laptop for students - Good condition</p>
+                        <div class="product-specs">
+                            <span>256GB SSD</span>
+                            <span>8GB RAM</span>
+                            <span>Intel i3-1115G4</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R5,999</span>
+                            <span class="original-price">R11,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="ASUS VivoBook 15 (i3)" data-price="5999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="laptops">
+                    <div class="product-image">
+                        <div class="product-badge">Creator</div>
+                        <img src="https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=800&h=800&fit=crop&crop=center" alt="ASUS ZenBook i5" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">ASUS ZenBook 14 (i5)</h3>
+                        <p class="product-description">Ultra-portable with premium build quality - Very good condition</p>
+                        <div class="product-specs">
+                            <span>512GB SSD</span>
+                            <span>16GB RAM</span>
+                            <span>Intel i5-1240P</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R13,999</span>
+                            <span class="original-price">R27,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="ASUS ZenBook 14 (i5)" data-price="13999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="laptops">
+                    <div class="product-image">
+                        <div class="product-badge">Ultimate</div>
+                        <img src="https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=800&h=800&fit=crop&crop=center" alt="ASUS ProArt i7" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">ASUS ProArt StudioBook (i7)</h3>
+                        <p class="product-description">Content creation powerhouse with RTX graphics - Excellent condition</p>
+                        <div class="product-specs">
+                            <span>1TB SSD</span>
+                            <span>32GB RAM</span>
+                            <span>Intel i7-12700H</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R26,999</span>
+                            <span class="original-price">R53,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="ASUS ProArt StudioBook (i7)" data-price="26999">Add to Cart</button>
+                    </div>
+                </div>
+
                 <!-- Smart Watches -->
                 <div class="product-card" data-category="smartwatches">
                     <div class="product-image">
                         <div class="product-badge">Health</div>
-                        <img src="https://images.unsplash.com/photo-1523275335684-37898b6baf30?w=500&h=500&fit=crop" alt="Apple Watch Ultra 2" class="product-img">
+                        <img src="https://images.unsplash.com/photo-1523275335684-37898b6baf30?w=1200&h=1200&fit=crop&crop=center&q=90" alt="Apple Watch Ultra 2" class="product-img">
                         <div class="product-overlay">
                             <button class="quick-view-btn">Quick View</button>
                         </div>
@@ -251,7 +857,7 @@
 
                 <div class="product-card" data-category="smartwatches">
                     <div class="product-image">
-                        <img src="https://images.unsplash.com/photo-1544117519-31a4b719223d?w=500&h=500&fit=crop" alt="Samsung Galaxy Watch 6" class="product-img">
+                        <img src="https://images.unsplash.com/photo-1544117519-31a4b719223d?w=1200&h=1200&fit=crop&crop=center&q=90" alt="Samsung Galaxy Watch 6" class="product-img">
                         <div class="product-overlay">
                             <button class="quick-view-btn">Quick View</button>
                         </div>
@@ -275,7 +881,7 @@
                 <div class="product-card" data-category="smartwatches">
                     <div class="product-image">
                         <div class="product-badge">Fitness</div>
-                        <img src="https://images.unsplash.com/photo-1579586337278-3f436f25d4d1?w=500&h=500&fit=crop" alt="Garmin Fenix 7X" class="product-img">
+                        <img src="https://images.unsplash.com/photo-1579586337278-3f436f25d4d1?w=1200&h=1200&fit=crop&crop=center&q=90" alt="Garmin Fenix 7X" class="product-img">
                         <div class="product-overlay">
                             <button class="quick-view-btn">Quick View</button>
                         </div>
@@ -293,6 +899,104 @@
                             <span class="original-price">R8,999</span>
                         </div>
                         <button class="add-to-cart-btn" data-product="Garmin Fenix 7X" data-price="3999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <!-- Additional Apple Watches -->
+                <div class="product-card" data-category="smartwatches">
+                    <div class="product-image">
+                        <div class="product-badge">Classic</div>
+                        <img src="https://images.unsplash.com/photo-1551816230-ef5deaed4a26?w=800&h=800&fit=crop&crop=center" alt="Apple Watch Series 8" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Apple Watch Series 8</h3>
+                        <p class="product-description">Advanced health sensors with temperature tracking - Very good condition</p>
+                        <div class="product-specs">
+                            <span>45mm</span>
+                            <span>GPS + Cellular</span>
+                            <span>Always-On Display</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R6,999</span>
+                            <span class="original-price">R13,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Apple Watch Series 8" data-price="6999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartwatches">
+                    <div class="product-image">
+                        <div class="product-badge">Affordable</div>
+                        <img src="https://images.unsplash.com/photo-1551816230-ef5deaed4a26?w=800&h=800&fit=crop&crop=center" alt="Apple Watch SE 2" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Apple Watch SE (2nd Gen)</h3>
+                        <p class="product-description">Essential Apple Watch features at great value - Good condition</p>
+                        <div class="product-specs">
+                            <span>40mm</span>
+                            <span>GPS</span>
+                            <span>Retina Display</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R3,999</span>
+                            <span class="original-price">R7,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Apple Watch SE (2nd Gen)" data-price="3999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <!-- Additional Samsung Watches -->
+                <div class="product-card" data-category="smartwatches">
+                    <div class="product-image">
+                        <div class="product-badge">Premium</div>
+                        <img src="https://images.unsplash.com/photo-1579586337278-3f436f25d4d1?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy Watch 5 Pro" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy Watch 5 Pro</h3>
+                        <p class="product-description">Rugged design with advanced GPS tracking - Excellent condition</p>
+                        <div class="product-specs">
+                            <span>45mm</span>
+                            <span>Titanium</span>
+                            <span>GPS + LTE</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R5,999</span>
+                            <span class="original-price">R11,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy Watch 5 Pro" data-price="5999">Add to Cart</button>
+                    </div>
+                </div>
+
+                <div class="product-card" data-category="smartwatches">
+                    <div class="product-image">
+                        <div class="product-badge">Classic</div>
+                        <img src="https://images.unsplash.com/photo-1579586337278-3f436f25d4d1?w=800&h=800&fit=crop&crop=center" alt="Samsung Galaxy Watch 4" class="product-img">
+                        <div class="product-overlay">
+                            <button class="quick-view-btn">Quick View</button>
+                        </div>
+                    </div>
+                    <div class="product-info">
+                        <h3 class="product-name">Samsung Galaxy Watch 4</h3>
+                        <p class="product-description">First Wear OS Samsung watch with body composition - Good condition</p>
+                        <div class="product-specs">
+                            <span>44mm</span>
+                            <span>Wear OS</span>
+                            <span>Body Composition</span>
+                        </div>
+                        <div class="product-price">
+                            <span class="current-price">R3,499</span>
+                            <span class="original-price">R6,999</span>
+                        </div>
+                        <button class="add-to-cart-btn" data-product="Samsung Galaxy Watch 4" data-price="3499">Add to Cart</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
📱 SMARTPHONES ADDED (21 total):
iPhone Models:
- iPhone X: R3,999 (was R7,999)
- iPhone XR: R4,499 (was R8,999)
- iPhone 11: R5,999 (was R11,999)
- iPhone 11 Pro: R7,499 (was R14,999)
- iPhone 11 Pro Max: R8,499 (was R16,999)
- iPhone 13: R9,999 (was R19,999)
- iPhone 13 Pro: R12,999 (was R25,999)
- iPhone 13 Pro Max: R14,999 (was R29,999)

Samsung Galaxy Models:
- Galaxy S23: R11,999 (was R23,999)
- Galaxy S23+: R13,999 (was R27,999)
- Galaxy S24+: R15,999 (was R31,999)

Samsung Mid-Range:
- Galaxy A54: R4,999 (was R9,999)
- Galaxy A34: R3,499 (was R6,999)
- Galaxy A14: R2,499 (was R4,999)
- Galaxy M54: R4,499 (was R8,999)
- Galaxy A24: R2,999 (was R5,999)

💻 LAPTOPS ADDED (12 total):
HP Laptops:
- HP Pavilion 15 (i3): R6,999 (was R13,999)
- HP Envy x360 (i5): R11,999 (was R23,999)
- HP Spectre x360 (i7): R16,999 (was R33,999)

Dell Laptops:
- Dell Inspiron 15 (i3): R6,499 (was R12,999)
- Dell Latitude 5520 (i5): R12,999 (was R25,999)
- Dell Precision 5570 (i7): R22,999 (was R45,999)

ASUS Laptops:
- ASUS VivoBook 15 (i3): R5,999 (was R11,999)
- ASUS ZenBook 14 (i5): R13,999 (was R27,999)
- ASUS ProArt StudioBook (i7): R26,999 (was R53,999)

⌚ SMARTWATCHES ADDED (9 total):
Apple Watches:
- Apple Watch Series 8: R6,999 (was R13,999)
- Apple Watch SE (2nd Gen): R3,999 (was R7,999)

Samsung Watches:
- Galaxy Watch 5 Pro: R5,999 (was R11,999)
- Galaxy Watch 4: R3,499 (was R6,999)

🖼️ IMAGE QUALITY IMPROVEMENTS:
- All images upgraded to 1200x1200 resolution
- Enhanced quality parameters (q=90)
- Better cropping and centering
- Consistent high-resolution display across all products

📊 CATALOG SUMMARY:
- Total Products: 42 devices
- Price Range: R2,499 - R26,999
- Average Discount: ~50% off retail prices
- Categories: Smartphones (21), Laptops (12), Smartwatches (9)